### PR TITLE
Add compatibility for Redmine 4.2

### DIFF
--- a/app/views/keys/index.html.erb
+++ b/app/views/keys/index.html.erb
@@ -75,7 +75,7 @@
   </div>
 <% end %>
 
-<% if Redmine::VERSION.to_s.start_with?('3.4', '4.0', '4.1')  %>
+<% if Redmine::VERSION.to_s.start_with?('3.4') or Redmine::VERSION.to_s.start_with?('4')  %>
     <%= context_menu %>
 <% else %>
     <%= context_menu project_keys_context_menus_path(@project) %>


### PR DESCRIPTION
This adds support for Redmine 4.2, [released about a month ago](https://www.redmine.org/news/130). All other version-dependent places seem to check for simply `start_with?('4')`, and all features seem to work fine after this fix.