### PR TITLE
Fix bug that exposes passwords from the projects a user has no access to.

### DIFF
--- a/app/models/vault/key.rb
+++ b/app/models/vault/key.rb
@@ -69,7 +69,7 @@ module Vault
     end
 
     def whitelisted?(user, project)
-      return true if user.admin || !user.allowed_to?(:whitelist_keys, project)
+      return true if user.admin || (!user.allowed_to?(:whitelist_keys, project) && user.allowed_to?(:view_project, project))
 
       whitelist_ids = self.whitelist.split(',')
       return true if whitelist_ids.include?(user.id.to_s)


### PR DESCRIPTION
To replicate bug:

Enable "WhiteList Keys" and "Keys All" permissions for a Role (e.g. to give support staff a list of all their passwords for the projects they support).

The top menu Passwords list then exposes the passwords for Projects the users don't have access to.